### PR TITLE
feat: providers package and video player

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-It uses [Turborepo](https://turborepo.org) and contains:
+This repository uses [Turborepo](https://turborepo.org) and contains:
 
 ```text
 .github
@@ -19,7 +19,9 @@ apps
       └─ Typesafe API calls using tRPC
 packages
   ├─ tmdb
-      └─ Typesafe API calls to The Movie Database
+  |   └─ Typesafe API calls to The Movie Database
+  └─ providers
+      └─ Typesafe API calls to the video providers 
 tooling
   ├─ eslint
   |   └─ shared, fine-grained, eslint presets
@@ -31,35 +33,9 @@ tooling
       └─ shared tsconfig you can extend from
 ```
 
-### Configure Expo `dev`-script
+## Getting started
 
-#### Use iOS Simulator
-
-1. Make sure you have XCode and XCommand Line Tools installed [as shown on expo docs](https://docs.expo.dev/workflow/ios-simulator).
-
-   > **NOTE:** If you just installed XCode, or if you have updated it, you need to open the simulator manually once. Run `npx expo start` in the root dir, and then enter `I` to launch Expo Go. After the manual launch, you can run `pnpm dev` in the root directory.
-
-   ```diff
-   +  "dev": "expo start --ios",
-   ```
-
-2. Run `pnpm dev` at the project root folder.
-
-#### Use Android Emulator
-
-1. Install Android Studio tools [as shown on expo docs](https://docs.expo.dev/workflow/android-studio-emulator).
-
-2. Change the `dev` script at `apps/expo/package.json` to open the Android emulator.
-
-   ```diff
-   +  "dev": "expo start --android",
-   ```
-
-3. Run `pnpm dev` at the project root folder.
-
-> **TIP:** It might be easier to run each app in separate terminal windows so you get the logs from each app separately. This is also required if you want your terminals to be interactive, e.g. to access the Expo QR code. You can run `pnpm --filter expo dev` and `pnpm --filter nextjs dev` to run each app in a separate terminal window.
-
-### 3. When it's time to add a new package
+### When it's time to add a new package
 
 To add a new package, simply run `pnpm turbo gen init` in the monorepo root. This will prompt you for a package name as well as if you want to install any dependencies to the new package (of course you can also do this yourself later).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ apps
 packages
   ├─ tmdb
   |   └─ Typesafe API calls to The Movie Database
-  └─ providers
+  └─ provider-utils
       └─ Typesafe API calls to the video providers 
 tooling
   ├─ eslint

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -5,7 +5,6 @@ const defineConfig = (): ExpoConfig => ({
   slug: "mw-mobile",
   scheme: "dev.movieweb.app",
   version: "0.1.0",
-  orientation: "portrait",
   icon: "./assets/images/icon.png",
   userInterfaceStyle: "automatic",
   splash: {
@@ -20,6 +19,7 @@ const defineConfig = (): ExpoConfig => ({
   ios: {
     bundleIdentifier: "dev.movieweb.app",
     supportsTablet: true,
+	requireFullScreen: true,
   },
   android: {
     package: "dev.movieweb.app",
@@ -41,7 +41,13 @@ const defineConfig = (): ExpoConfig => ({
     tsconfigPaths: true,
     typedRoutes: true,
   },
-  plugins: ["expo-router"],
+  plugins: ["expo-router", [
+	"expo-screen-orientation",
+	{
+	  initialOrientation: "DEFAULT"
+	}
+  ]
+],
 });
 
 export default defineConfig;

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -19,7 +19,7 @@ const defineConfig = (): ExpoConfig => ({
   ios: {
     bundleIdentifier: "dev.movieweb.app",
     supportsTablet: true,
-	requireFullScreen: true,
+    requireFullScreen: true,
   },
   android: {
     package: "dev.movieweb.app",
@@ -41,13 +41,15 @@ const defineConfig = (): ExpoConfig => ({
     tsconfigPaths: true,
     typedRoutes: true,
   },
-  plugins: ["expo-router", [
-	"expo-screen-orientation",
-	{
-	  initialOrientation: "DEFAULT"
-	}
-  ]
-],
+  plugins: [
+    "expo-router",
+    [
+      "expo-screen-orientation",
+      {
+        initialOrientation: "DEFAULT",
+      },
+    ],
+  ],
 });
 
 export default defineConfig;

--- a/apps/expo/index.js
+++ b/apps/expo/index.js
@@ -1,0 +1,1 @@
+import "expo-router/entry";

--- a/apps/expo/index.js
+++ b/apps/expo/index.js
@@ -1,1 +1,2 @@
 import "expo-router/entry";
+import "@react-native-anywhere/polyfill-base64";

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -19,7 +19,10 @@
   },
   "dependencies": {
     "@expo/metro-config": "^0.17.3",
+    "@movie-web/provider-utils": "*",
     "@movie-web/tmdb": "*",
+    "@react-native-anywhere/polyfill-base64": "0.0.1-alpha.0",
+    "@react-navigation/native": "^6.1.9",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "expo": "~50.0.5",

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -38,6 +38,7 @@
     "react-native-reanimated": "~3.6.2",
     "react-native-safe-area-context": "~4.8.2",
     "react-native-screens": "~3.29.0",
+    "react-native-video": "6.0.0-beta.5",
     "react-native-web": "^0.19.10",
     "tailwind-merge": "^2.2.1"
   },

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -26,6 +26,7 @@
     "expo-constants": "~15.4.5",
     "expo-linking": "~6.2.2",
     "expo-router": "~3.4.6",
+    "expo-screen-orientation": "~6.4.1",
     "expo-splash-screen": "~0.26.4",
     "expo-status-bar": "~1.11.1",
     "expo-web-browser": "^12.8.2",

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -2,7 +2,7 @@
   "name": "@movie-web/mobile",
   "version": "0.1.0",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "index.js",
   "scripts": {
     "clean": "git clean -xdf .expo .turbo node_modules",
     "dev": "expo start",

--- a/apps/expo/src/app/components/item/item.tsx
+++ b/apps/expo/src/app/components/item/item.tsx
@@ -1,4 +1,5 @@
-import { Image, View } from "react-native";
+import { useRouter } from "expo-router";
+import { Image, View, TouchableOpacity } from "react-native";
 
 import { Text } from "~/components/ui/Text";
 
@@ -11,10 +12,18 @@ export interface ItemData {
 }
 
 export default function Item({ data }: { data: ItemData }) {
+  const router = useRouter();
   const { title, type, year, posterUrl } = data;
 
+  const handlePress = () => {
+    console.log('Item pressed. Opening VideoPlayer...');
+	router.push('/video-player');
+  };
+
   return (
-    <View className="w-full">
+    <TouchableOpacity onPress={handlePress} style={{ width: '100%' }}>
+      {
+	<View className="w-full">
       <View className="mb-2 aspect-[9/14] w-full overflow-hidden rounded-2xl">
         <Image
           source={{
@@ -32,5 +41,7 @@ export default function Item({ data }: { data: ItemData }) {
         <Text className="text-sm text-gray-600">{year}</Text>
       </View>
     </View>
+	}
+    </TouchableOpacity>
   );
 }

--- a/apps/expo/src/app/components/item/item.tsx
+++ b/apps/expo/src/app/components/item/item.tsx
@@ -16,8 +16,11 @@ export default function Item({ data }: { data: ItemData }) {
   const { title, type, year, posterUrl } = data;
 
   const handlePress = () => {
-    console.log('Item pressed. Opening VideoPlayer...');
 	router.push('/video-player');
+	// router.push({
+	// 	pathname: '/video-player',
+	// 	params: { videoUrl: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4' }
+	//   });
   };
 
   return (

--- a/apps/expo/src/app/components/item/item.tsx
+++ b/apps/expo/src/app/components/item/item.tsx
@@ -1,5 +1,12 @@
+import { Image, TouchableOpacity, View } from "react-native";
 import { useRouter } from "expo-router";
-import { Image, View, TouchableOpacity } from "react-native";
+import * as ScreenOrientation from "expo-screen-orientation";
+
+import {
+  getVideoUrl,
+  transformSearchResultToScrapeMedia,
+} from "@movie-web/provider-utils";
+import { fetchMediaDetails } from "@movie-web/tmdb";
 
 import { Text } from "~/components/ui/Text";
 
@@ -13,38 +20,67 @@ export interface ItemData {
 
 export default function Item({ data }: { data: ItemData }) {
   const router = useRouter();
-  const { title, type, year, posterUrl } = data;
+  const { id, title, type, year, posterUrl } = data;
 
-  const handlePress = () => {
-	router.push('/video-player');
-	// router.push({
-	// 	pathname: '/video-player',
-	// 	params: { videoUrl: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4' }
-	//   });
+  const handlePress = async () => {
+    router.push("/video-player");
+
+    const media = await fetchMediaDetails(id, type);
+    if (!media) return;
+
+    const { result } = media;
+    let season: number | undefined;
+    let episode: number | undefined;
+
+    if (type === "tv") {
+      // season = <chosen by user> ?? undefined;
+      // episode = <chosen by user> ?? undefined;
+    }
+
+    const scrapeMedia = transformSearchResultToScrapeMedia(
+      type,
+      result,
+      season,
+      episode,
+    );
+
+    const videoUrl = await getVideoUrl(scrapeMedia);
+    if (!videoUrl) {
+      await ScreenOrientation.lockAsync(
+        ScreenOrientation.OrientationLock.PORTRAIT_UP,
+      );
+      return router.push("/(tabs)");
+    }
+    console.log(videoUrl);
+
+    router.push({
+      pathname: "/video-player",
+      params: { videoUrl },
+    });
   };
 
   return (
-    <TouchableOpacity onPress={handlePress} style={{ width: '100%' }}>
+    <TouchableOpacity onPress={handlePress} style={{ width: "100%" }}>
       {
-	<View className="w-full">
-      <View className="mb-2 aspect-[9/14] w-full overflow-hidden rounded-2xl">
-        <Image
-          source={{
-            uri: posterUrl,
-          }}
-          className="h-full w-full"
-        />
-      </View>
-      <Text className="font-bold">{title}</Text>
-      <View className="flex-row items-center gap-3">
-        <Text className="text-xs text-gray-600">
-          {type === "tv" ? "Show" : "Movie"}
-        </Text>
-        <View className="h-1 w-1 rounded-3xl bg-gray-600" />
-        <Text className="text-sm text-gray-600">{year}</Text>
-      </View>
-    </View>
-	}
+        <View className="w-full">
+          <View className="mb-2 aspect-[9/14] w-full overflow-hidden rounded-2xl">
+            <Image
+              source={{
+                uri: posterUrl,
+              }}
+              className="h-full w-full"
+            />
+          </View>
+          <Text className="font-bold">{title}</Text>
+          <View className="flex-row items-center gap-3">
+            <Text className="text-xs text-gray-600">
+              {type === "tv" ? "Show" : "Movie"}
+            </Text>
+            <View className="h-1 w-1 rounded-3xl bg-gray-600" />
+            <Text className="text-sm text-gray-600">{year}</Text>
+          </View>
+        </View>
+      }
     </TouchableOpacity>
   );
 }

--- a/apps/expo/src/app/video-player.tsx
+++ b/apps/expo/src/app/video-player.tsx
@@ -1,0 +1,82 @@
+import React, { Component } from 'react';
+import { StyleSheet, View, ActivityIndicator } from 'react-native';
+import type { VideoRef } from 'react-native-video';
+import Video from 'react-native-video';
+
+interface VideoPlayerState {
+  videoUrl: string;
+  fullscreen: boolean;
+  isLoading: boolean;
+  paused: boolean;
+}
+
+class VideoPlayer extends Component<object, VideoPlayerState> {
+  private videoPlayer: React.RefObject<VideoRef>;
+
+  constructor(props: object) {
+    super(props);
+    this.state = {
+      videoUrl: 'your_video_url',
+      fullscreen: true,
+      isLoading: true,
+      paused: false
+    };
+    this.videoPlayer = React.createRef();
+  }
+
+  componentDidMount() {
+    if (this.videoPlayer.current) {
+      this.videoPlayer.current.presentFullscreenPlayer();
+    }
+  }
+
+  onVideoLoadStart = () => {
+    this.setState({ isLoading: true });
+  };
+
+  onReadyForDisplay = () => {
+    this.setState({ isLoading: false });
+  };
+
+  onVideoError = () => {
+    console.log("Video playback error");
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Video
+          ref={this.videoPlayer}
+          source={{ uri: this.state.videoUrl }}
+          style={styles.fullScreen}
+          fullscreen={this.state.fullscreen}
+          paused={this.state.paused}
+          onLoadStart={this.onVideoLoadStart}
+          onReadyForDisplay={this.onReadyForDisplay}
+          onError={this.onVideoError}
+        />
+        {this.state.isLoading && (
+          <ActivityIndicator size="large" color="#0000ff" />
+        )}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'black',
+  },
+  fullScreen: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  }
+});
+
+export default VideoPlayer;

--- a/apps/expo/src/app/video-player.tsx
+++ b/apps/expo/src/app/video-player.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import type { VideoRef } from 'react-native-video';
 import Video from 'react-native-video';
 import * as ScreenOrientation from 'expo-screen-orientation';
+import { useLocalSearchParams } from "expo-router";
 
 interface VideoPlayerState {
   videoUrl: string;
@@ -12,13 +13,23 @@ interface VideoPlayerState {
   paused: boolean;
 }
 
-class VideoPlayer extends Component<object, VideoPlayerState> {
-  private videoPlayer: React.RefObject<VideoRef>;
+interface VideoPlayerProps {
+	videoUrl: string;
+}
 
-  constructor(props: object) {
+export default function VideoPlayerWrapper() {
+	const params = useLocalSearchParams();
+	const videoUrl = typeof params.videoUrl === 'string' ? params.videoUrl : '';
+	return <VideoPlayer videoUrl={videoUrl} />;
+  }
+
+  class VideoPlayer extends Component<VideoPlayerProps, VideoPlayerState> {
+	private videoPlayer: React.RefObject<VideoRef>;
+
+   constructor(props: VideoPlayerProps) {
     super(props);
     this.state = {
-      videoUrl: '',
+      videoUrl: props.videoUrl || '',
       fullscreen: true,
       isLoading: true,
       paused: false
@@ -31,10 +42,14 @@ class VideoPlayer extends Component<object, VideoPlayerState> {
 	  await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
 	};
   
-	if (this.videoPlayer.current) {
-	  this.videoPlayer.current.presentFullscreenPlayer();
-	  void lockOrientation();
-	}
+	const { videoUrl } = this.props;
+	
+	this.setState({ videoUrl }, () => {
+	  if (this.videoPlayer.current) {
+		this.videoPlayer.current.presentFullscreenPlayer();
+		void lockOrientation();
+	  }
+	});
   }
 
   componentWillUnmount() {
@@ -98,5 +113,3 @@ const styles = StyleSheet.create({
   },
     
 });
-
-export default VideoPlayer;

--- a/apps/expo/src/app/video-player.tsx
+++ b/apps/expo/src/app/video-player.tsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import { StyleSheet, ActivityIndicator } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import type { VideoRef } from 'react-native-video';
-import Video from 'react-native-video';
-import * as ScreenOrientation from 'expo-screen-orientation';
+import type { VideoRef } from "react-native-video";
+import React, { Component } from "react";
+import { ActivityIndicator, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import Video from "react-native-video";
 import { useLocalSearchParams } from "expo-router";
+import * as ScreenOrientation from "expo-screen-orientation";
 
 interface VideoPlayerState {
   videoUrl: string;
@@ -14,53 +14,57 @@ interface VideoPlayerState {
 }
 
 interface VideoPlayerProps {
-	videoUrl: string;
+  videoUrl: string;
 }
 
 export default function VideoPlayerWrapper() {
-	const params = useLocalSearchParams();
-	const videoUrl = typeof params.videoUrl === 'string' ? params.videoUrl : '';
-	return <VideoPlayer videoUrl={videoUrl} />;
-  }
+  const params = useLocalSearchParams();
+  const videoUrl = typeof params.videoUrl === "string" ? params.videoUrl : "";
+  return <VideoPlayer videoUrl={videoUrl} />;
+}
 
-  class VideoPlayer extends Component<VideoPlayerProps, VideoPlayerState> {
-	private videoPlayer: React.RefObject<VideoRef>;
+class VideoPlayer extends Component<VideoPlayerProps, VideoPlayerState> {
+  private videoPlayer: React.RefObject<VideoRef>;
 
-   constructor(props: VideoPlayerProps) {
+  constructor(props: VideoPlayerProps) {
     super(props);
     this.state = {
-      videoUrl: props.videoUrl || '',
+      videoUrl: props.videoUrl || "",
       fullscreen: true,
       isLoading: true,
-      paused: false
+      paused: false,
     };
     this.videoPlayer = React.createRef();
   }
 
   componentDidMount() {
-	const lockOrientation = async () => {
-	  await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
-	};
-  
-	const { videoUrl } = this.props;
-	
-	this.setState({ videoUrl }, () => {
-	  if (this.videoPlayer.current) {
-		this.videoPlayer.current.presentFullscreenPlayer();
-		void lockOrientation();
-	  }
-	});
+    const lockOrientation = async () => {
+      await ScreenOrientation.lockAsync(
+        ScreenOrientation.OrientationLock.LANDSCAPE,
+      );
+    };
+
+    const { videoUrl } = this.props;
+
+    this.setState({ videoUrl }, () => {
+      if (this.videoPlayer.current) {
+        this.videoPlayer.current.presentFullscreenPlayer();
+        void lockOrientation();
+      }
+    });
   }
 
   componentWillUnmount() {
-	const unlockOrientation = async () => {
-	  await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
-	}
+    const unlockOrientation = async () => {
+      await ScreenOrientation.lockAsync(
+        ScreenOrientation.OrientationLock.PORTRAIT_UP,
+      );
+    };
 
-	if (this.videoPlayer.current) {
-	  this.videoPlayer.current.dismissFullscreenPlayer();
-	}
-	void unlockOrientation();
+    if (this.videoPlayer.current) {
+      this.videoPlayer.current.dismissFullscreenPlayer();
+    }
+    void unlockOrientation();
   }
 
   onVideoLoadStart = () => {
@@ -71,9 +75,9 @@ export default function VideoPlayerWrapper() {
     this.setState({ isLoading: false });
   };
 
-//   onVideoError = () => {  // probably useful later
-//     console.log("Video playback error");
-//   };
+  //   onVideoError = () => {  // probably useful later
+  //     console.log("Video playback error");
+  //   };
 
   render() {
     return (
@@ -84,7 +88,7 @@ export default function VideoPlayerWrapper() {
           style={styles.fullScreen}
           fullscreen={this.state.fullscreen}
           paused={this.state.paused}
-		  controls={true}
+          controls={true}
           onLoadStart={this.onVideoLoadStart}
           onReadyForDisplay={this.onReadyForDisplay}
           // onError={this.onVideoError}
@@ -98,18 +102,18 @@ export default function VideoPlayerWrapper() {
 }
 
 const styles = StyleSheet.create({
+  // taken from example, probably needs to be nativewind stuff instead
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'black',
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "black",
   },
   fullScreen: {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     left: 0,
     bottom: 0,
     right: 0,
   },
-    
 });

--- a/apps/expo/src/app/video-player.tsx
+++ b/apps/expo/src/app/video-player.tsx
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
-import { StyleSheet, View, ActivityIndicator } from 'react-native';
+import { StyleSheet, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import type { VideoRef } from 'react-native-video';
 import Video from 'react-native-video';
+import * as ScreenOrientation from 'expo-screen-orientation';
 
 interface VideoPlayerState {
   videoUrl: string;
@@ -16,7 +18,7 @@ class VideoPlayer extends Component<object, VideoPlayerState> {
   constructor(props: object) {
     super(props);
     this.state = {
-      videoUrl: 'your_video_url',
+      videoUrl: '',
       fullscreen: true,
       isLoading: true,
       paused: false
@@ -25,9 +27,25 @@ class VideoPlayer extends Component<object, VideoPlayerState> {
   }
 
   componentDidMount() {
-    if (this.videoPlayer.current) {
-      this.videoPlayer.current.presentFullscreenPlayer();
-    }
+	const lockOrientation = async () => {
+	  await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
+	};
+  
+	if (this.videoPlayer.current) {
+	  this.videoPlayer.current.presentFullscreenPlayer();
+	  void lockOrientation();
+	}
+  }
+
+  componentWillUnmount() {
+	const unlockOrientation = async () => {
+	  await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+	}
+
+	if (this.videoPlayer.current) {
+	  this.videoPlayer.current.dismissFullscreenPlayer();
+	}
+	void unlockOrientation();
   }
 
   onVideoLoadStart = () => {
@@ -38,27 +56,28 @@ class VideoPlayer extends Component<object, VideoPlayerState> {
     this.setState({ isLoading: false });
   };
 
-  onVideoError = () => {
-    console.log("Video playback error");
-  };
+//   onVideoError = () => {  // probably useful later
+//     console.log("Video playback error");
+//   };
 
   render() {
     return (
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         <Video
           ref={this.videoPlayer}
           source={{ uri: this.state.videoUrl }}
           style={styles.fullScreen}
           fullscreen={this.state.fullscreen}
           paused={this.state.paused}
+		  controls={true}
           onLoadStart={this.onVideoLoadStart}
           onReadyForDisplay={this.onReadyForDisplay}
-          onError={this.onVideoError}
+          // onError={this.onVideoError}
         />
         {this.state.isLoading && (
           <ActivityIndicator size="large" color="#0000ff" />
         )}
-      </View>
+      </SafeAreaView>
     );
   }
 }
@@ -76,7 +95,8 @@ const styles = StyleSheet.create({
     left: 0,
     bottom: 0,
     right: 0,
-  }
+  },
+    
 });
 
 export default VideoPlayer;

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -29,6 +29,7 @@
   },
   "prettier": "@movie-web/prettier-config",
   "dependencies": {
-    "@movie-web/providers": "^2.1.1"
+    "@movie-web/providers": "^2.1.1",
+    "tmdb-ts": "^1.6.1"
   }
 }

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@movie-web/provider-utils",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf .turbo node_modules",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@movie-web/eslint-config": "workspace:^0.2.0",
+    "@movie-web/prettier-config": "workspace:^0.1.0",
+    "@movie-web/tsconfig": "workspace:^0.1.0",
+    "eslint": "^8.56.0",
+    "prettier": "^3.1.1",
+    "typescript": "^5.3.3"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@movie-web/eslint-config/base"
+    ]
+  },
+  "prettier": "@movie-web/prettier-config",
+  "dependencies": {
+    "@movie-web/providers": "^2.1.1"
+  }
+}

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -1,1 +1,3 @@
 export const name = "provider-utils";
+export * from "./video";
+export * from "./util";

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -1,0 +1,1 @@
+export const name = "provider-utils";

--- a/packages/provider-utils/src/util.ts
+++ b/packages/provider-utils/src/util.ts
@@ -1,0 +1,43 @@
+import type { MovieDetails, TvShowDetails } from "tmdb-ts";
+
+import type { ScrapeMedia } from "@movie-web/providers";
+
+export function transformSearchResultToScrapeMedia(
+  type: "tv" | "movie",
+  result: TvShowDetails | MovieDetails,
+  season?: number,
+  episode?: number,
+): ScrapeMedia {
+  if (type === "tv") {
+    const tvResult = result as TvShowDetails;
+    return {
+      type: "show",
+      tmdbId: tvResult.id.toString(),
+      title: tvResult.name,
+      releaseYear: new Date(tvResult.first_air_date).getFullYear(),
+      season: {
+        number: season ?? tvResult.seasons[0]?.season_number ?? 1,
+        tmdbId: season
+          ? tvResult.seasons
+              .find((s) => s.season_number === season)
+              ?.id.toString() ?? ""
+          : tvResult.seasons[0]?.id.toString() ?? "",
+      },
+      episode: {
+        number: episode ?? 1,
+        tmdbId: "",
+      },
+    };
+  }
+  if (type === "movie") {
+    const movieResult = result as MovieDetails;
+    return {
+      type: "movie",
+      tmdbId: movieResult.id.toString(),
+      title: movieResult.title,
+      releaseYear: new Date(movieResult.release_date).getFullYear(),
+    };
+  }
+
+  throw new Error("Invalid type parameter");
+}

--- a/packages/provider-utils/src/video.ts
+++ b/packages/provider-utils/src/video.ts
@@ -1,47 +1,57 @@
 import type {
-	FileBasedStream,
-	Qualities,
-	RunnerOptions,
-	ScrapeMedia} from '@movie-web/providers';
+  FileBasedStream,
+  Qualities,
+  RunnerOptions,
+  ScrapeMedia,
+} from "@movie-web/providers";
 import {
-	makeProviders,
-	makeStandardFetcher,
-	targets,
-  } from '@movie-web/providers';
+  makeProviders,
+  makeStandardFetcher,
+  targets,
+} from "@movie-web/providers";
 
-export async function getVideoUrl(media: ScrapeMedia): Promise<string|null> {
-	const providers = makeProviders({
-		fetcher: makeStandardFetcher(fetch),
-		target: targets.NATIVE,
-		consistentIpForRequests: true,
-	  });
+export async function getVideoUrl(media: ScrapeMedia): Promise<string | null> {
+  const providers = makeProviders({
+    fetcher: makeStandardFetcher(fetch),
+    target: targets.NATIVE,
+    consistentIpForRequests: true,
+  });
 
-	const options: RunnerOptions = {
-		media
-	};
+  const options: RunnerOptions = {
+    media,
+  };
 
-	const results = await providers.runAll(options);
-	if (!results) return null;
+  const results = await providers.runAll(options);
+  if (!results) return null;
 
-	let highestQuality;
-	let url;
-	
-	switch (results.stream.type) {
-		case 'file':
-			highestQuality = findHighestQuality(results.stream);
-			url = highestQuality ? results.stream.qualities[highestQuality]?.url : null;
-			return url ?? null;
-		case 'hls':
-			return results.stream.playlist;
-	}
+  let highestQuality;
+  let url;
+
+  switch (results.stream.type) {
+    case "file":
+      highestQuality = findHighestQuality(results.stream);
+      url = highestQuality
+        ? results.stream.qualities[highestQuality]?.url
+        : null;
+      return url ?? null;
+    case "hls":
+      return results.stream.playlist;
+  }
 }
 
 function findHighestQuality(stream: FileBasedStream): Qualities | undefined {
-	const qualityOrder: Qualities[] = ['4k', '1080', '720', '480', '360', 'unknown'];
-	for (const quality of qualityOrder) {
-		if (stream.qualities[quality]) {
-			return quality;
-		}
-	}
-	return undefined;
+  const qualityOrder: Qualities[] = [
+    "4k",
+    "1080",
+    "720",
+    "480",
+    "360",
+    "unknown",
+  ];
+  for (const quality of qualityOrder) {
+    if (stream.qualities[quality]) {
+      return quality;
+    }
+  }
+  return undefined;
 }

--- a/packages/provider-utils/src/video.ts
+++ b/packages/provider-utils/src/video.ts
@@ -1,0 +1,47 @@
+import type {
+	FileBasedStream,
+	Qualities,
+	RunnerOptions,
+	ScrapeMedia} from '@movie-web/providers';
+import {
+	makeProviders,
+	makeStandardFetcher,
+	targets,
+  } from '@movie-web/providers';
+
+export async function getVideoUrl(media: ScrapeMedia): Promise<string|null> {
+	const providers = makeProviders({
+		fetcher: makeStandardFetcher(fetch),
+		target: targets.NATIVE,
+		consistentIpForRequests: true,
+	  });
+
+	const options: RunnerOptions = {
+		media
+	};
+
+	const results = await providers.runAll(options);
+	if (!results) return null;
+
+	let highestQuality;
+	let url;
+	
+	switch (results.stream.type) {
+		case 'file':
+			highestQuality = findHighestQuality(results.stream);
+			url = highestQuality ? results.stream.qualities[highestQuality]?.url : null;
+			return url ?? null;
+		case 'hls':
+			return results.stream.playlist;
+	}
+}
+
+function findHighestQuality(stream: FileBasedStream): Qualities | undefined {
+	const qualityOrder: Qualities[] = ['4k', '1080', '720', '480', '360', 'unknown'];
+	for (const quality of qualityOrder) {
+		if (stream.qualities[quality]) {
+			return quality;
+		}
+	}
+	return undefined;
+}

--- a/packages/provider-utils/tsconfig.json
+++ b/packages/provider-utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@movie-web/tsconfig/base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+  },
+  "include": ["*.ts", "src"],
+  "exclude": ["node_modules"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,18 @@ importers:
       '@expo/metro-config':
         specifier: ^0.17.3
         version: 0.17.3(@react-native/babel-preset@0.73.20)
+      '@movie-web/provider-utils':
+        specifier: '*'
+        version: link:../../packages/provider-utils
       '@movie-web/tmdb':
         specifier: '*'
         version: link:../../packages/tmdb
+      '@react-native-anywhere/polyfill-base64':
+        specifier: 0.0.1-alpha.0
+        version: 0.0.1-alpha.0
+      '@react-navigation/native':
+        specifier: ^6.1.9
+        version: 6.1.9(react-native@0.73.2)(react@18.2.0)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -149,6 +158,9 @@ importers:
       '@movie-web/providers':
         specifier: ^2.1.1
         version: 2.1.1
+      tmdb-ts:
+        specifier: ^1.6.1
+        version: 1.6.1
     devDependencies:
       '@movie-web/eslint-config':
         specifier: workspace:^0.2.0
@@ -2387,6 +2399,12 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@react-native-anywhere/polyfill-base64@0.0.1-alpha.0:
+    resolution: {integrity: sha512-OF3idcETV622AyFvvK54ot2EG0G43tZTZJyWtFHtrEKUmoUvSuC5DOMeLino0TwBQJn2s26MBnIPVgokBJb/xw==}
+    dependencies:
+      base-64: 0.1.0
+    dev: false
+
   /@react-native-community/cli-clean@12.3.0:
     resolution: {integrity: sha512-iAgLCOWYRGh9ukr+eVQnhkV/OqN3V2EGd/in33Ggn/Mj4uO6+oUncXFwB+yjlyaUNz6FfjudhIz09yYGSF+9sg==}
     dependencies:
@@ -3837,6 +3855,10 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /base-64@0.1.0:
+    resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
+    dev: false
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       expo-router:
         specifier: ~3.4.6
         version: 3.4.6(expo-constants@15.4.5)(expo-linking@6.2.2)(expo-modules-autolinking@1.10.2)(expo-status-bar@1.11.1)(expo@50.0.5)(react-dom@18.2.0)(react-native-reanimated@3.6.2)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.2)(react@18.2.0)
+      expo-screen-orientation:
+        specifier: ~6.4.1
+        version: 6.4.1(expo@50.0.5)
       expo-splash-screen:
         specifier: ~0.26.4
         version: 0.26.4(expo-modules-autolinking@1.10.2)(expo@50.0.5)
@@ -5376,6 +5379,14 @@ packages:
       - react-dom
       - react-native
       - supports-color
+    dev: false
+
+  /expo-screen-orientation@6.4.1(expo@50.0.5):
+    resolution: {integrity: sha512-VM0C9ORNL1aT6Dr2OUeryzV519n0FjtXI2m+HlijOMi1QT2bPg4tBkCd7HLgywU4dZ1Esa46ewUudmk+fOqmMQ==}
+    peerDependencies:
+      expo: '*'
+    dependencies:
+      expo: 50.0.5(@babel/core@7.23.9)(@react-native/babel-preset@0.73.20)
     dev: false
 
   /expo-splash-screen@0.26.4(expo-modules-autolinking@1.10.2)(expo@50.0.5):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       react-native-screens:
         specifier: ~3.29.0
         version: 3.29.0(react-native@0.73.2)(react@18.2.0)
+      react-native-video:
+        specifier: 6.0.0-beta.5
+        version: 6.0.0-beta.5(react-native@0.73.2)(react@18.2.0)
       react-native-web:
         specifier: ^0.19.10
         version: 0.19.10(react-dom@18.2.0)(react@18.2.0)
@@ -8616,6 +8619,16 @@ packages:
       react-freeze: 1.0.3(react@18.2.0)
       react-native: 0.73.2(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0)
       warn-once: 0.1.1
+    dev: false
+
+  /react-native-video@6.0.0-beta.5(react-native@0.73.2)(react@18.2.0):
+    resolution: {integrity: sha512-dAfIXvtxsMI8TE3Q+1MHTP1brq3/V2VsPKVDtU8E+JcF963y5upnBb8JFiG8Yl4s4qAoQum2P02fZE30stQOHg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+    dependencies:
+      react: 18.2.0
+      react-native: 0.73.2(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0)
     dev: false
 
   /react-native-web@0.19.10(react-dom@18.2.0)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,31 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
 
+  packages/provider-utils:
+    dependencies:
+      '@movie-web/providers':
+        specifier: ^2.1.1
+        version: 2.1.1
+    devDependencies:
+      '@movie-web/eslint-config':
+        specifier: workspace:^0.2.0
+        version: link:../../tooling/eslint
+      '@movie-web/prettier-config':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/prettier
+      '@movie-web/tsconfig':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/typescript
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
+      prettier:
+        specifier: ^3.1.1
+        version: 3.2.4
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
+
   packages/tmdb:
     dependencies:
       tmdb-ts:
@@ -2283,6 +2308,20 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /@movie-web/providers@2.1.1:
+    resolution: {integrity: sha512-g2CA/w3YlGw3b3v6yDSgUIUdym4rFs4CzZOo/OlyL4HtsFH9mk182ukt7HYSxgddCEJRjl81LZZc3/pLRIGcMA==}
+    dependencies:
+      cheerio: 1.0.0-rc.12
+      crypto-js: 4.2.0
+      form-data: 4.0.0
+      iso-639-1: 3.1.0
+      nanoid: 3.3.7
+      node-fetch: 2.7.0
+      unpacker: 1.0.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3828,6 +3867,10 @@ packages:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
     dev: false
 
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
+
   /bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
     dependencies:
@@ -4054,6 +4097,30 @@ packages:
 
   /charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+    dev: false
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
     dev: false
 
   /chokidar@3.5.3:
@@ -4393,6 +4460,10 @@ packages:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
     dev: false
 
+  /crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    dev: false
+
   /crypto-random-string@1.0.0:
     resolution: {integrity: sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==}
     engines: {node: '>=4'}
@@ -4407,6 +4478,21 @@ packages:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
     dependencies:
       hyphenate-style-name: 1.0.4
+    dev: false
+
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
     dev: false
 
   /cssesc@3.0.0:
@@ -4637,6 +4723,33 @@ packages:
     dependencies:
       esutils: 2.0.3
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
     dependencies:
@@ -4678,6 +4791,11 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: false
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
     dev: false
 
   /env-editor@0.4.2:
@@ -5515,6 +5633,15 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: false
@@ -5894,6 +6021,15 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       lru-cache: 6.0.0
+    dev: false
+
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /http-errors@2.0.0:
@@ -6386,6 +6522,11 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /iso-639-1@3.1.0:
+    resolution: {integrity: sha512-rWcHp9dcNbxa5C8jA/cxFlWNFNwy5Vup0KcFvgA8sPQs9ZeJHj/Eq0Y8Yz2eL8XlWYpxw4iwh9FfTeVxyqdRMw==}
+    engines: {node: '>=6.0'}
+    dev: false
 
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -7586,6 +7727,12 @@ packages:
     dependencies:
       path-key: 3.1.1
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
     dev: false
@@ -7900,6 +8047,19 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       pngjs: 3.4.0
+    dev: false
+
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
     dev: false
 
   /parseurl@1.3.3:
@@ -9884,6 +10044,10 @@ packages:
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  /unpacker@1.0.1:
+    resolution: {integrity: sha512-0HTljwp8+JBdITpoHcK1LWi7X9U2BspUmWv78UWZh7NshYhbh1nec8baY/iSbe2OQTZ2bhAtVdnr6/BTD0DKVg==}
+    dev: false
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
   },


### PR DESCRIPTION
- [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
- [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
- [x] I have tested all of my changes.

This pr:
- adds the `provider-utils` package
- adds a video player using `react-native-video`
- implements basic playback via providers (no season/ep selector)

Additional notes:
- the entrypoint moved from package.json to index.js because:
- `react-native-video` requires a development build since expo go can't build native modules -> expo go builds no longer work
- metro doesn't find the entrypoint in a non expo-go build if it isn't a source file
- base64 polyfill installed and invoked in entrypoint to accomodates /providers needs
